### PR TITLE
Rename Parser to ConnectifyParser

### DIFF
--- a/src/main/java/connectify/logic/LogicManager.java
+++ b/src/main/java/connectify/logic/LogicManager.java
@@ -10,7 +10,7 @@ import connectify.commons.core.LogsCenter;
 import connectify.logic.commands.Command;
 import connectify.logic.commands.CommandResult;
 import connectify.logic.commands.exceptions.CommandException;
-import connectify.logic.parser.AddressBookParser;
+import connectify.logic.parser.ConnectifyParser;
 import connectify.logic.parser.exceptions.ParseException;
 import connectify.model.Model;
 import connectify.model.ReadOnlyAddressBook;
@@ -31,7 +31,7 @@ public class LogicManager implements Logic {
 
     private final Model model;
     private final Storage storage;
-    private final AddressBookParser addressBookParser;
+    private final ConnectifyParser connectifyParser;
 
     /**
      * Constructs a {@code LogicManager} with the given {@code Model} and {@code Storage}.
@@ -39,7 +39,7 @@ public class LogicManager implements Logic {
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
-        addressBookParser = new AddressBookParser();
+        connectifyParser = new ConnectifyParser();
     }
 
     @Override
@@ -47,7 +47,7 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = addressBookParser.parseCommand(commandText);
+        Command command = connectifyParser.parseCommand(commandText);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/connectify/logic/parser/ConnectifyParser.java
+++ b/src/main/java/connectify/logic/parser/ConnectifyParser.java
@@ -22,7 +22,7 @@ import connectify.logic.parser.exceptions.ParseException;
 /**
  * Parses user input.
  */
-public class AddressBookParser {
+public class ConnectifyParser {
 
     /**
      * Used for initial separation of command word and args.

--- a/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
+++ b/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
@@ -29,9 +29,9 @@ import connectify.testutil.EditPersonDescriptorBuilder;
 import connectify.testutil.PersonBuilder;
 import connectify.testutil.PersonUtil;
 
-public class AddressBookParserTest {
+public class ConnectifyParserTest {
 
-    private final AddressBookParser parser = new AddressBookParser();
+    private final ConnectifyParser parser = new ConnectifyParser();
 
     @Test
     public void parseCommand_add() throws Exception {


### PR DESCRIPTION
This PR refactors the parser from AddressBookParser to ConnectifyParser. It also includes the necessary refactoring to ensure consistency among the test cases. This serves 2 purposes:

- Remove all traces of AB3
- Ensure consistency of the names within Connectify