### PR TITLE
Branch Refactor "delete" Command to "deletePerson" Command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -60,12 +60,12 @@ Please provide a valid email address.
 
 ### Deleting Contacts
 
-#### Command: `delete`
+#### Command: `deletePerson`
 
-The **delete** command allows you to remove contacts from your Connectify database. To delete a contact, you need to specify the contact's index.
+The **deletePerson** command allows you to remove contacts from your Connectify database. To delete a contact, you need to specify the contact's index.
 
 ```
-delete INDEX
+deletePerson INDEX
 ```
 
 - `INDEX`: Provide the index of the contact you want to delete.
@@ -74,7 +74,7 @@ delete INDEX
 
 To delete the contact named John Doe at index 1, use the following command:
 ```
-delete 1
+deletePerson 1
 ```
 
 **Successful Output:**
@@ -153,10 +153,10 @@ That is not a valid command.
 
 ## Command Summary
 
-Action | Format, Examples
---------|------------------
-**Add** | `add n/NAME e/EMAIL [t/TAG]…` <br> e.g., `add n/John Doe
-**Delete** | `delete INDEX` <br> e.g., `delete 1`
-**List** | `list`
-**Exit** | `exit`
+| Action           | Format, Examples              |
+|------------------|-------------------------------|
+| **Add**          | `add n/NAME e/EMAIL [t/TAG]…` <br> e.g., `add n/John Doe |
+| **DeletePerson** | `deletePerson INDEX` <br> e.g., `delete 1` |
+| **List**         | `list`                        |
+| **Exit**         | `exit`                        |
 

--- a/src/main/java/connectify/logic/commands/DeletePersonCommand.java
+++ b/src/main/java/connectify/logic/commands/DeletePersonCommand.java
@@ -14,9 +14,9 @@ import connectify.model.person.Person;
 /**
  * Deletes a person identified using it's displayed index from the address book.
  */
-public class DeleteCommand extends Command {
+public class DeletePersonCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_WORD = "deletePerson";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
@@ -27,7 +27,7 @@ public class DeleteCommand extends Command {
 
     private final Index targetIndex;
 
-    public DeleteCommand(Index targetIndex) {
+    public DeletePersonCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
     }
 
@@ -52,11 +52,11 @@ public class DeleteCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof DeleteCommand)) {
+        if (!(other instanceof DeletePersonCommand)) {
             return false;
         }
 
-        DeleteCommand otherDeleteCommand = (DeleteCommand) other;
+        DeletePersonCommand otherDeleteCommand = (DeletePersonCommand) other;
         return targetIndex.equals(otherDeleteCommand.targetIndex);
     }
 

--- a/src/main/java/connectify/logic/parser/AddressBookParser.java
+++ b/src/main/java/connectify/logic/parser/AddressBookParser.java
@@ -11,7 +11,7 @@ import connectify.commons.core.LogsCenter;
 import connectify.logic.commands.AddCommand;
 import connectify.logic.commands.ClearCommand;
 import connectify.logic.commands.Command;
-import connectify.logic.commands.DeleteCommand;
+import connectify.logic.commands.DeletePersonCommand;
 import connectify.logic.commands.EditCommand;
 import connectify.logic.commands.ExitCommand;
 import connectify.logic.commands.FindCommand;
@@ -59,8 +59,8 @@ public class AddressBookParser {
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
 
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+        case DeletePersonCommand.COMMAND_WORD:
+            return new DeletePersonCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/connectify/logic/parser/ConnectifyParser.java
+++ b/src/main/java/connectify/logic/parser/ConnectifyParser.java
@@ -11,7 +11,7 @@ import connectify.commons.core.LogsCenter;
 import connectify.logic.commands.AddCommand;
 import connectify.logic.commands.ClearCommand;
 import connectify.logic.commands.Command;
-import connectify.logic.commands.DeleteCommand;
+import connectify.logic.commands.DeletePersonCommand;
 import connectify.logic.commands.EditCommand;
 import connectify.logic.commands.ExitCommand;
 import connectify.logic.commands.FindCommand;
@@ -59,8 +59,8 @@ public class ConnectifyParser {
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
 
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
+        case DeletePersonCommand.COMMAND_WORD:
+            return new DeletePersonCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();

--- a/src/main/java/connectify/logic/parser/DeletePersonCommandParser.java
+++ b/src/main/java/connectify/logic/parser/DeletePersonCommandParser.java
@@ -3,26 +3,26 @@ package connectify.logic.parser;
 import static connectify.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import connectify.commons.core.index.Index;
-import connectify.logic.commands.DeleteCommand;
+import connectify.logic.commands.DeletePersonCommand;
 import connectify.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new DeleteCommand object
  */
-public class DeleteCommandParser implements Parser<DeleteCommand> {
+public class DeletePersonCommandParser implements Parser<DeletePersonCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public DeleteCommand parse(String args) throws ParseException {
+    public DeletePersonCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            return new DeleteCommand(index);
+            return new DeletePersonCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeletePersonCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/test/java/connectify/logic/LogicManagerTest.java
+++ b/src/test/java/connectify/logic/LogicManagerTest.java
@@ -56,8 +56,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        String deletePersonCommand = "deletePerson 9";
+        assertCommandException(deletePersonCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test

--- a/src/test/java/connectify/logic/commands/DeletePersonCommandTest.java
+++ b/src/test/java/connectify/logic/commands/DeletePersonCommandTest.java
@@ -1,12 +1,14 @@
 package connectify.logic.commands;
 
-import static connectify.logic.commands.CommandTestUtil.assertCommandSuccess;
-import static connectify.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
-import static connectify.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
-import static connectify.testutil.TypicalPersons.getTypicalAddressBook;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static connectify.logic.commands.CommandTestUtil.assertCommandFailure;
+import static connectify.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static connectify.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static connectify.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static connectify.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static connectify.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,74 +21,74 @@ import connectify.model.person.Person;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for
- * {@code DeleteCommand}.
+ * {@code DeletePersonCommand}.
  */
-public class DeleteCommandTest {
+public class DeletePersonCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeletePersonCommand deletePersonCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+        String expectedMessage = String.format(DeletePersonCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deletePersonCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeletePersonCommand deletePersonCommand = new DeletePersonCommand(outOfBoundIndex);
 
-        CommandTestUtil.assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deletePersonCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        CommandTestUtil.showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeletePersonCommand deletePersonCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+        String expectedMessage = String.format(DeletePersonCommand.MESSAGE_DELETE_PERSON_SUCCESS,
                 Messages.format(personToDelete));
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
         showNoPerson(expectedModel);
 
-        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(deletePersonCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidIndexFilteredList_throwsCommandException() {
-        CommandTestUtil.showPersonAtIndex(model, INDEX_FIRST_PERSON);
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
 
         Index outOfBoundIndex = INDEX_SECOND_PERSON;
         // ensures that outOfBoundIndex is still in bounds of address book list
         assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
 
-        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+        DeletePersonCommand deletePersonCommand = new DeletePersonCommand(outOfBoundIndex);
 
-        CommandTestUtil.assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        assertCommandFailure(deletePersonCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
     @Test
     public void equals() {
-        DeleteCommand deleteFirstCommand = new DeleteCommand(INDEX_FIRST_PERSON);
-        DeleteCommand deleteSecondCommand = new DeleteCommand(INDEX_SECOND_PERSON);
+        DeletePersonCommand deleteFirstCommand = new DeletePersonCommand(INDEX_FIRST_PERSON);
+        DeletePersonCommand deleteSecondCommand = new DeletePersonCommand(INDEX_SECOND_PERSON);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
 
         // same values -> returns true
-        DeleteCommand deleteFirstCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeletePersonCommand deleteFirstCommandCopy = new DeletePersonCommand(INDEX_FIRST_PERSON);
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
 
         // different types -> returns false
@@ -102,9 +104,9 @@ public class DeleteCommandTest {
     @Test
     public void toStringMethod() {
         Index targetIndex = Index.fromOneBased(1);
-        DeleteCommand deleteCommand = new DeleteCommand(targetIndex);
-        String expected = DeleteCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
-        assertEquals(expected, deleteCommand.toString());
+        DeletePersonCommand deletePersonCommand = new DeletePersonCommand(targetIndex);
+        String expected = DeletePersonCommand.class.getCanonicalName() + "{targetIndex=" + targetIndex + "}";
+        assertEquals(expected, deletePersonCommand.toString());
     }
 
     /**

--- a/src/test/java/connectify/logic/commands/DeletePersonCommandTest.java
+++ b/src/test/java/connectify/logic/commands/DeletePersonCommandTest.java
@@ -1,14 +1,14 @@
 package connectify.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static connectify.logic.commands.CommandTestUtil.assertCommandFailure;
 import static connectify.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static connectify.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static connectify.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static connectify.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static connectify.testutil.TypicalPersons.getTypicalAddressBook;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
+++ b/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import connectify.logic.commands.AddCommand;
 import connectify.logic.commands.ClearCommand;
-import connectify.logic.commands.DeleteCommand;
+import connectify.logic.commands.DeletePersonCommand;
 import connectify.logic.commands.EditCommand;
 import connectify.logic.commands.EditCommand.EditPersonDescriptor;
 import connectify.logic.commands.ExitCommand;
@@ -48,9 +48,9 @@ public class ConnectifyParserTest {
 
     @Test
     public void parseCommand_delete() throws Exception {
-        DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
-        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+        DeletePersonCommand command = (DeletePersonCommand) parser.parseCommand(
+                DeletePersonCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeletePersonCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/connectify/logic/parser/DeletePersonCommandParserTest.java
+++ b/src/test/java/connectify/logic/parser/DeletePersonCommandParserTest.java
@@ -7,26 +7,27 @@ import static connectify.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
 
-import connectify.logic.commands.DeleteCommand;
+import connectify.logic.commands.DeletePersonCommand;
 
 /**
  * As we are only doing white-box testing, our test cases do not cover path variations
- * outside of the DeleteCommand code. For example, inputs "1" and "1 abc" take the
- * same path through the DeleteCommand, and therefore we test only one of them.
+ * outside of the DeletePersonCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the DeletePersonCommand, and therefore we test only one of them.
  * The path variation for those two cases occur inside the ParserUtil, and
  * therefore should be covered by the ParserUtilTest.
  */
-public class DeleteCommandParserTest {
+public class DeletePersonCommandParserTest {
 
-    private DeleteCommandParser parser = new DeleteCommandParser();
+    private DeletePersonCommandParser parser = new DeletePersonCommandParser();
 
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
-        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
+    public void parse_validArgs_returnsDeletePersonCommand() {
+        assertParseSuccess(parser, "1", new DeletePersonCommand(INDEX_FIRST_PERSON));
     }
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                           DeletePersonCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
This PR fixes #46.

We currently use a generic "delete" command, which lacks clarity and specificity in its purpose.

As we introduce the "Company" class, this change is necessary to improve code readability and maintainability. By renaming the command to "deletePerson," its functionality becomes more self-explanatory, making it easier for developers to understand its purpose and use it correctly.

In this refactor, all occurrences of the "delete" command are renamed to "deletePerson" throughout the codebase. This includes updating function and variable names, as well as modifying tests and the User Guide.

This approach is chosen because it aligns with best practices for naming conventions, where commands and functions should have descriptive names that clearly indicate their purpose.