### PR TITLE
Branch Refactor "add" Command to "addPerson" Command

### DIFF
--- a/src/main/java/connectify/logic/commands/AddPersonCommand.java
+++ b/src/main/java/connectify/logic/commands/AddPersonCommand.java
@@ -16,9 +16,9 @@ import connectify.model.person.Person;
 /**
  * Adds a person to the address book.
  */
-public class AddCommand extends Command {
+public class AddPersonCommand extends Command {
 
-    public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_WORD = "addPerson";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
             + "Parameters: "
@@ -41,9 +41,9 @@ public class AddCommand extends Command {
     private final Person toAdd;
 
     /**
-     * Creates an AddCommand to add the specified {@code Person}
+     * Creates an AddPersonCommand to add the specified {@code Person}
      */
-    public AddCommand(Person person) {
+    public AddPersonCommand(Person person) {
         requireNonNull(person);
         toAdd = person;
     }
@@ -67,12 +67,12 @@ public class AddCommand extends Command {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof AddCommand)) {
+        if (!(other instanceof AddPersonCommand)) {
             return false;
         }
 
-        AddCommand otherAddCommand = (AddCommand) other;
-        return toAdd.equals(otherAddCommand.toAdd);
+        AddPersonCommand otherAddPersonCommand = (AddPersonCommand) other;
+        return toAdd.equals(otherAddPersonCommand.toAdd);
     }
 
     @Override

--- a/src/main/java/connectify/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/connectify/logic/parser/AddPersonCommandParser.java
@@ -5,7 +5,7 @@ import static connectify.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import connectify.logic.commands.AddCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.parser.exceptions.ParseException;
 import connectify.model.person.Address;
 import connectify.model.person.Email;
@@ -15,16 +15,16 @@ import connectify.model.person.Phone;
 import connectify.model.tag.Tag;
 
 /**
- * Parses input arguments and creates a new AddCommand object
+ * Parses input arguments and creates a new AddPersonCommand object
  */
-public class AddCommandParser implements Parser<AddCommand> {
+public class AddPersonCommandParser implements Parser<AddPersonCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddCommand
-     * and returns an AddCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the AddPersonCommand
+     * and returns an AddPersonCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public AddCommand parse(String args) throws ParseException {
+    public AddPersonCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_PHONE, CliSyntax.PREFIX_EMAIL,
                         CliSyntax.PREFIX_ADDRESS, CliSyntax.PREFIX_TAG);
@@ -32,7 +32,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_ADDRESS,
                 CliSyntax.PREFIX_PHONE, CliSyntax.PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_PHONE, CliSyntax.PREFIX_EMAIL,
@@ -45,7 +45,7 @@ public class AddCommandParser implements Parser<AddCommand> {
 
         Person person = new Person(name, phone, email, address, tagList);
 
-        return new AddCommand(person);
+        return new AddPersonCommand(person);
     }
 
     /**

--- a/src/main/java/connectify/logic/parser/AddressBookParser.java
+++ b/src/main/java/connectify/logic/parser/AddressBookParser.java
@@ -8,8 +8,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import connectify.commons.core.LogsCenter;
-import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.AddCompanyCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.ClearCommand;
 import connectify.logic.commands.Command;
 import connectify.logic.commands.DeletePersonCommand;

--- a/src/main/java/connectify/logic/parser/AddressBookParser.java
+++ b/src/main/java/connectify/logic/parser/AddressBookParser.java
@@ -8,7 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import connectify.commons.core.LogsCenter;
-import connectify.logic.commands.AddCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.AddCompanyCommand;
 import connectify.logic.commands.ClearCommand;
 import connectify.logic.commands.Command;
@@ -54,8 +54,8 @@ public class AddressBookParser {
 
         switch (commandWord) {
 
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+        case AddPersonCommand.COMMAND_WORD:
+            return new AddPersonCommandParser().parse(arguments);
 
         case AddCompanyCommand.COMMAND_WORD:
             return new AddCompanyCommandParser().parse(arguments);

--- a/src/main/java/connectify/logic/parser/ConnectifyParser.java
+++ b/src/main/java/connectify/logic/parser/ConnectifyParser.java
@@ -8,7 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import connectify.commons.core.LogsCenter;
-import connectify.logic.commands.AddCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.AddCompanyCommand;
 import connectify.logic.commands.ClearCommand;
 import connectify.logic.commands.Command;
@@ -54,8 +54,8 @@ public class ConnectifyParser {
 
         switch (commandWord) {
 
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+        case AddPersonCommand.COMMAND_WORD:
+            return new AddPersonCommandParser().parse(arguments);
 
         case AddCompanyCommand.COMMAND_WORD:
             return new AddCompanyCommandParser().parse(arguments);

--- a/src/main/java/connectify/logic/parser/ConnectifyParser.java
+++ b/src/main/java/connectify/logic/parser/ConnectifyParser.java
@@ -8,8 +8,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import connectify.commons.core.LogsCenter;
-import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.AddCompanyCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.ClearCommand;
 import connectify.logic.commands.Command;
 import connectify.logic.commands.DeletePersonCommand;

--- a/src/test/java/connectify/logic/LogicManagerTest.java
+++ b/src/test/java/connectify/logic/LogicManagerTest.java
@@ -168,7 +168,8 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
-        String addPersonCommand = AddPersonCommand.COMMAND_WORD + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
+        String addPersonCommand = AddPersonCommand.COMMAND_WORD
+                + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
                 + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY;
         Person expectedPerson = new PersonBuilder(TypicalPersons.AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();

--- a/src/test/java/connectify/logic/LogicManagerTest.java
+++ b/src/test/java/connectify/logic/LogicManagerTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import connectify.logic.commands.AddCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.CommandResult;
 import connectify.logic.commands.CommandTestUtil;
 import connectify.logic.commands.ListCommand;
@@ -168,11 +168,11 @@ public class LogicManagerTest {
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
-        String addCommand = AddCommand.COMMAND_WORD + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
+        String addPersonCommand = AddPersonCommand.COMMAND_WORD + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
                 + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY;
         Person expectedPerson = new PersonBuilder(TypicalPersons.AMY).withTags().build();
         ModelManager expectedModel = new ModelManager();
         expectedModel.addPerson(expectedPerson);
-        assertCommandFailure(addCommand, CommandException.class, expectedMessage, expectedModel);
+        assertCommandFailure(addPersonCommand, CommandException.class, expectedMessage, expectedModel);
     }
 }

--- a/src/test/java/connectify/logic/commands/AddPersonCommandIntegrationTest.java
+++ b/src/test/java/connectify/logic/commands/AddPersonCommandIntegrationTest.java
@@ -14,9 +14,9 @@ import connectify.model.person.Person;
 import connectify.testutil.PersonBuilder;
 
 /**
- * Contains integration tests (interaction with the Model) for {@code AddCommand}.
+ * Contains integration tests (interaction with the Model) for {@code AddPersonCommand}.
  */
-public class AddCommandIntegrationTest {
+public class AddPersonCommandIntegrationTest {
 
     private Model model;
 
@@ -32,16 +32,16 @@ public class AddCommandIntegrationTest {
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.addPerson(validPerson);
 
-        assertCommandSuccess(new AddCommand(validPerson), model,
-                String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+        assertCommandSuccess(new AddPersonCommand(validPerson), model,
+                String.format(AddPersonCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
                 expectedModel);
     }
 
     @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person personInList = model.getAddressBook().getPersonList().get(0);
-        CommandTestUtil.assertCommandFailure(new AddCommand(personInList), model,
-                AddCommand.MESSAGE_DUPLICATE_PERSON);
+        CommandTestUtil.assertCommandFailure(new AddPersonCommand(personInList), model,
+                AddPersonCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
 }

--- a/src/test/java/connectify/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/connectify/logic/commands/AddPersonCommandTest.java
@@ -52,7 +52,8 @@ public class AddPersonCommandTest {
         AddPersonCommand addPersonCommand = new AddPersonCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddPersonCommand.MESSAGE_DUPLICATE_PERSON, () -> addPersonCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddPersonCommand.MESSAGE_DUPLICATE_PERSON,
+                     () -> addPersonCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/connectify/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/connectify/logic/commands/AddPersonCommandTest.java
@@ -27,11 +27,11 @@ import connectify.testutil.PersonBuilder;
 import javafx.collections.ObservableList;
 
 
-public class AddCommandTest {
+public class AddPersonCommandTest {
 
     @Test
     public void constructor_nullPerson_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddCommand(null));
+        assertThrows(NullPointerException.class, () -> new AddPersonCommand(null));
     }
 
     @Test
@@ -39,9 +39,9 @@ public class AddCommandTest {
         ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
         Person validPerson = new PersonBuilder().build();
 
-        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
+        CommandResult commandResult = new AddPersonCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
+        assertEquals(String.format(AddPersonCommand.MESSAGE_SUCCESS, Messages.format(validPerson)),
                 commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }
@@ -49,24 +49,24 @@ public class AddCommandTest {
     @Test
     public void execute_duplicatePerson_throwsCommandException() {
         Person validPerson = new PersonBuilder().build();
-        AddCommand addCommand = new AddCommand(validPerson);
+        AddPersonCommand addPersonCommand = new AddPersonCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddPersonCommand.MESSAGE_DUPLICATE_PERSON, () -> addPersonCommand.execute(modelStub));
     }
 
     @Test
     public void equals() {
         Person alice = new PersonBuilder().withName("Alice").build();
         Person bob = new PersonBuilder().withName("Bob").build();
-        AddCommand addAliceCommand = new AddCommand(alice);
-        AddCommand addBobCommand = new AddCommand(bob);
+        AddPersonCommand addAliceCommand = new AddPersonCommand(alice);
+        AddPersonCommand addBobCommand = new AddPersonCommand(bob);
 
         // same object -> returns true
         assertTrue(addAliceCommand.equals(addAliceCommand));
 
         // same values -> returns true
-        AddCommand addAliceCommandCopy = new AddCommand(alice);
+        AddPersonCommand addAliceCommandCopy = new AddPersonCommand(alice);
         assertTrue(addAliceCommand.equals(addAliceCommandCopy));
 
         // different types -> returns false
@@ -81,9 +81,9 @@ public class AddCommandTest {
 
     @Test
     public void toStringMethod() {
-        AddCommand addCommand = new AddCommand(ALICE);
-        String expected = AddCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
-        assertEquals(expected, addCommand.toString());
+        AddPersonCommand addPersonCommand = new AddPersonCommand(ALICE);
+        String expected = AddPersonCommand.class.getCanonicalName() + "{toAdd=" + ALICE + "}";
+        assertEquals(expected, addPersonCommand.toString());
     }
 
     /**

--- a/src/test/java/connectify/logic/commands/AddPersonCommandTest.java
+++ b/src/test/java/connectify/logic/commands/AddPersonCommandTest.java
@@ -52,8 +52,8 @@ public class AddPersonCommandTest {
         AddPersonCommand addPersonCommand = new AddPersonCommand(validPerson);
         ModelStub modelStub = new ModelStubWithPerson(validPerson);
 
-        assertThrows(CommandException.class, AddPersonCommand.MESSAGE_DUPLICATE_PERSON,
-                     () -> addPersonCommand.execute(modelStub));
+        assertThrows(CommandException.class, AddPersonCommand.MESSAGE_DUPLICATE_PERSON, () ->
+                     addPersonCommand.execute(modelStub));
     }
 
     @Test

--- a/src/test/java/connectify/logic/parser/AddPersonCommandParserTest.java
+++ b/src/test/java/connectify/logic/parser/AddPersonCommandParserTest.java
@@ -11,7 +11,7 @@ import static connectify.testutil.TypicalPersons.BOB;
 import org.junit.jupiter.api.Test;
 
 import connectify.logic.Messages;
-import connectify.logic.commands.AddCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.CommandTestUtil;
 import connectify.model.person.Address;
 import connectify.model.person.Email;
@@ -21,8 +21,8 @@ import connectify.model.person.Phone;
 import connectify.model.tag.Tag;
 import connectify.testutil.PersonBuilder;
 
-public class AddCommandParserTest {
-    private AddCommandParser parser = new AddCommandParser();
+public class AddPersonCommandParserTest {
+    private AddPersonCommandParser parser = new AddPersonCommandParser();
 
     @Test
     public void parse_allFieldsPresent_success() {
@@ -32,7 +32,7 @@ public class AddCommandParserTest {
         CommandParserTestUtil.assertParseSuccess(parser, CommandTestUtil.PREAMBLE_WHITESPACE
                     + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                     + CommandTestUtil.ADDRESS_DESC_BOB + CommandTestUtil.TAG_DESC_FRIEND,
-                    new AddCommand(expectedPerson));
+                    new AddPersonCommand(expectedPerson));
 
 
         // multiple tags - all accepted
@@ -41,7 +41,7 @@ public class AddCommandParserTest {
         CommandParserTestUtil.assertParseSuccess(parser,
             CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                     + CommandTestUtil.ADDRESS_DESC_BOB + CommandTestUtil.TAG_DESC_HUSBAND
-                    + CommandTestUtil.TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
+                    + CommandTestUtil.TAG_DESC_FRIEND, new AddPersonCommand(expectedPersonMultipleTags));
     }
 
     @Test
@@ -117,12 +117,12 @@ public class AddCommandParserTest {
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         CommandParserTestUtil.assertParseSuccess(parser, CommandTestUtil.NAME_DESC_AMY
                     + CommandTestUtil.PHONE_DESC_AMY + CommandTestUtil.EMAIL_DESC_AMY
-                    + CommandTestUtil.ADDRESS_DESC_AMY, new AddCommand(expectedPerson));
+                    + CommandTestUtil.ADDRESS_DESC_AMY, new AddPersonCommand(expectedPerson));
     }
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE);
 
         // missing name prefix
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.VALID_NAME_BOB
@@ -190,6 +190,6 @@ public class AddCommandParserTest {
                 + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
                 + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
+++ b/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
@@ -13,8 +13,8 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.AddCompanyCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.ClearCommand;
 import connectify.logic.commands.DeletePersonCommand;
 import connectify.logic.commands.EditCommand;

--- a/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
+++ b/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
@@ -47,7 +47,7 @@ public class ConnectifyParserTest {
     @Test
     public void parseCommand_addCompany() throws Exception {
         Company company = new CompanyBuilder().build();
-        AddCompanyCommand command = (AddCompanyCommand) parser.parseCommand(CompanyUtil.getAddPersonCommand(company));
+        AddCompanyCommand command = (AddCompanyCommand) parser.parseCommand(CompanyUtil.getAddCommand(company));
         assertEquals(new AddCompanyCommand(company), command);
     }
 

--- a/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
+++ b/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import connectify.logic.commands.AddCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.AddCompanyCommand;
 import connectify.logic.commands.ClearCommand;
 import connectify.logic.commands.DeletePersonCommand;
@@ -40,14 +40,14 @@ public class ConnectifyParserTest {
     @Test
     public void parseCommand_add() throws Exception {
         Person person = new PersonBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
-        assertEquals(new AddCommand(person), command);
+        AddPersonCommand command = (AddPersonCommand) parser.parseCommand(PersonUtil.getAddPersonCommand(person));
+        assertEquals(new AddPersonCommand(person), command);
     }
 
     @Test
     public void parseCommand_addCompany() throws Exception {
         Company company = new CompanyBuilder().build();
-        AddCompanyCommand command = (AddCompanyCommand) parser.parseCommand(CompanyUtil.getAddCommand(company));
+        AddCompanyCommand command = (AddCompanyCommand) parser.parseCommand(CompanyUtil.getAddPersonCommand(company));
         assertEquals(new AddCompanyCommand(company), command);
     }
 

--- a/src/test/java/connectify/testutil/PersonUtil.java
+++ b/src/test/java/connectify/testutil/PersonUtil.java
@@ -8,7 +8,7 @@ import static connectify.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
 
-import connectify.logic.commands.AddCommand;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.EditCommand.EditPersonDescriptor;
 import connectify.model.person.Person;
 import connectify.model.tag.Tag;
@@ -21,8 +21,8 @@ public class PersonUtil {
     /**
      * Returns an add command string for adding the {@code person}.
      */
-    public static String getAddCommand(Person person) {
-        return AddCommand.COMMAND_WORD + " " + getPersonDetails(person);
+    public static String getAddPersonCommand(Person person) {
+        return AddPersonCommand.COMMAND_WORD + " " + getPersonDetails(person);
     }
 
     /**


### PR DESCRIPTION
This PR fixes #45.

We currently use a generic "add" command, which lacks clarity and specificity in its purpose.

As we introduce the "Company" class, this change is necessary to improve code readability and maintainability. By renaming the command to "addPerson," its functionality becomes more self-explanatory, making it easier for developers to understand its purpose and use it correctly.

In this refactor, all occurrences of the "add" command are renamed to "addPerson" throughout the codebase. This includes updating function and variable names, as well as modifying tests and the User Guide.

This approach is chosen because it aligns with best practices for naming conventions, where commands and functions should have descriptive names that clearly indicate their purpose.