### PR TITLE
Add support for PersonPriority

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -110,6 +110,7 @@ The fields are:
 - `[p/PHONE]` (optional) allows you to change the person's phone number.
 - `[e/EMAIL]` (optional) allows you to change the person's email.
 - `[a/ADDRESS]` (optional) allows you to change the person's address.
+- `[pr/PRIORITY]` (optional) allows you to change the person's priority level.
 - `[t/TAG]` (optional) allows you to add or remove tags for the person.
 
 

--- a/src/main/java/connectify/logic/LogicManager.java
+++ b/src/main/java/connectify/logic/LogicManager.java
@@ -47,7 +47,6 @@ public class LogicManager implements Logic {
     @Override
     public CommandResult execute(String commandText) throws CommandException, ParseException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
-
         CommandResult commandResult;
         Command command = connectifyParser.parseCommand(commandText);
         commandResult = command.execute(model);

--- a/src/main/java/connectify/logic/commands/AddPersonCommand.java
+++ b/src/main/java/connectify/logic/commands/AddPersonCommand.java
@@ -5,6 +5,7 @@ import static connectify.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static connectify.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connectify.logic.parser.CliSyntax.PREFIX_NAME;
 import static connectify.logic.parser.CliSyntax.PREFIX_PHONE;
+import static connectify.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static connectify.logic.parser.CliSyntax.PREFIX_TAG;
 import static java.util.Objects.requireNonNull;
 
@@ -32,6 +33,8 @@ public class AddPersonCommand extends Command {
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
             + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_COMPANY + "COMPANY_INDEX]...\n"
+            + "[" + PREFIX_PRIORITY + "PRIORITY]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
@@ -39,7 +42,8 @@ public class AddPersonCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney "
-            + PREFIX_COMPANY + "1";
+            + PREFIX_COMPANY + "1 "
+            + PREFIX_PRIORITY + "1";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/connectify/logic/commands/EditPersonCommand.java
+++ b/src/main/java/connectify/logic/commands/EditPersonCommand.java
@@ -61,6 +61,7 @@ public class EditPersonCommand extends Command {
 
     public static final String MESSAGE_NO_COMPANY_PROVIDED = "No company provided.";
 
+
     private final Index index;
 
     private final Index companyIndex;
@@ -73,7 +74,6 @@ public class EditPersonCommand extends Command {
     public EditPersonCommand(Index index, Index companyIndex, EditPersonDescriptor editPersonDescriptor) {
         requireNonNull(index);
         requireNonNull(editPersonDescriptor);
-
         this.index = index;
         this.editPersonDescriptor = new EditPersonDescriptor(editPersonDescriptor);
         this.companyIndex = companyIndex;
@@ -187,7 +187,7 @@ public class EditPersonCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags, personPriority);
         }
 
         public void setName(Name name) {
@@ -274,6 +274,7 @@ public class EditPersonCommand extends Command {
                     .add("email", email)
                     .add("address", address)
                     .add("tags", tags)
+                    .add("priority", personPriority)
                     .toString();
         }
     }

--- a/src/main/java/connectify/logic/commands/EditPersonCommand.java
+++ b/src/main/java/connectify/logic/commands/EditPersonCommand.java
@@ -5,6 +5,7 @@ import static connectify.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static connectify.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connectify.logic.parser.CliSyntax.PREFIX_NAME;
 import static connectify.logic.parser.CliSyntax.PREFIX_PHONE;
+import static connectify.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static connectify.logic.parser.CliSyntax.PREFIX_TAG;
 import static connectify.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static java.util.Objects.requireNonNull;
@@ -27,6 +28,7 @@ import connectify.model.person.Address;
 import connectify.model.person.Email;
 import connectify.model.person.Name;
 import connectify.model.person.Person;
+import connectify.model.person.PersonPriority;
 import connectify.model.person.Phone;
 import connectify.model.tag.Tag;
 
@@ -46,6 +48,7 @@ public class EditPersonCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_PRIORITY + "PRIORITY] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_COMPANY + "1 "
@@ -120,8 +123,9 @@ public class EditPersonCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        PersonPriority updatedPriority = editPersonDescriptor.getPersonPriority().orElse(personToEdit.getPriority());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedPriority);
     }
 
     @Override
@@ -159,7 +163,9 @@ public class EditPersonCommand extends Command {
         private Address address;
         private Set<Tag> tags;
 
-        private Index companyIndex;
+        private PersonPriority personPriority;
+
+
 
         public EditPersonDescriptor() {}
 
@@ -173,6 +179,8 @@ public class EditPersonCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
+            setPersonPriority(toCopy.personPriority);
+
         }
 
         /**
@@ -229,6 +237,14 @@ public class EditPersonCommand extends Command {
          */
         public Optional<Set<Tag>> getTags() {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        public void setPersonPriority(PersonPriority personPriority) {
+            this.personPriority = personPriority;
+        }
+
+        public Optional<PersonPriority> getPersonPriority() {
+            return Optional.ofNullable(personPriority);
         }
 
         @Override

--- a/src/main/java/connectify/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/connectify/logic/parser/AddPersonCommandParser.java
@@ -12,6 +12,7 @@ import connectify.model.person.Address;
 import connectify.model.person.Email;
 import connectify.model.person.Name;
 import connectify.model.person.Person;
+import connectify.model.person.PersonPriority;
 import connectify.model.person.Phone;
 import connectify.model.tag.Tag;
 
@@ -28,10 +29,11 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
     public AddPersonCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_PHONE, CliSyntax.PREFIX_EMAIL,
-                        CliSyntax.PREFIX_ADDRESS, CliSyntax.PREFIX_TAG, CliSyntax.PREFIX_COMPANY);
+                        CliSyntax.PREFIX_ADDRESS, CliSyntax.PREFIX_TAG,
+                        CliSyntax.PREFIX_COMPANY, CliSyntax.PREFIX_PRIORITY);
 
         if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_ADDRESS,
-                CliSyntax.PREFIX_PHONE, CliSyntax.PREFIX_EMAIL)
+                CliSyntax.PREFIX_PHONE, CliSyntax.PREFIX_EMAIL, CliSyntax.PREFIX_PRIORITY)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
         }
@@ -43,9 +45,11 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(CliSyntax.PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(CliSyntax.PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(CliSyntax.PREFIX_TAG));
-        Index companyIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_COMPANY).orElse("1"));
 
-        Person person = new Person(name, phone, email, address, tagList);
+        // Defaults to first company if no company index is provided
+        Index companyIndex = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_COMPANY).orElse("1"));
+        PersonPriority priority = ParserUtil.parsePersonPriority(argMultimap.getValue(CliSyntax.PREFIX_PRIORITY).get());
+        Person person = new Person(name, phone, email, address, tagList, priority);
 
         return new AddPersonCommand(person, companyIndex);
     }

--- a/src/main/java/connectify/logic/parser/CliSyntax.java
+++ b/src/main/java/connectify/logic/parser/CliSyntax.java
@@ -18,4 +18,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_WEBSITE = new Prefix("w/");
     public static final Prefix PREFIX_COMPANY = new Prefix("c/");
 
+    public static final Prefix PREFIX_PRIORITY = new Prefix("pr/");
+
 }

--- a/src/main/java/connectify/logic/parser/EditPersonCommandParser.java
+++ b/src/main/java/connectify/logic/parser/EditPersonCommandParser.java
@@ -6,6 +6,7 @@ import static connectify.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static connectify.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connectify.logic.parser.CliSyntax.PREFIX_NAME;
 import static connectify.logic.parser.CliSyntax.PREFIX_PHONE;
+import static connectify.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static connectify.logic.parser.CliSyntax.PREFIX_TAG;
 import static java.util.Objects.requireNonNull;
 
@@ -33,7 +34,7 @@ public class EditPersonCommandParser implements Parser<EditPersonCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_COMPANY, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-                            PREFIX_ADDRESS, PREFIX_TAG);
+                            PREFIX_ADDRESS, PREFIX_TAG, PREFIX_PRIORITY);
 
         Index index;
 
@@ -72,10 +73,14 @@ public class EditPersonCommandParser implements Parser<EditPersonCommand> {
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
+        if (argMultimap.getValue(PREFIX_PRIORITY).isPresent()) {
+            editPersonDescriptor.setPersonPriority(ParserUtil.parsePersonPriority(
+                    argMultimap.getValue(PREFIX_PRIORITY).get()));
+        }
+
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditPersonCommand.MESSAGE_NOT_EDITED);
         }
-
         return new EditPersonCommand(index, companyIndex, editPersonDescriptor);
     }
 

--- a/src/main/java/connectify/logic/parser/ParserUtil.java
+++ b/src/main/java/connectify/logic/parser/ParserUtil.java
@@ -12,6 +12,7 @@ import connectify.logic.parser.exceptions.ParseException;
 import connectify.model.person.Address;
 import connectify.model.person.Email;
 import connectify.model.person.Name;
+import connectify.model.person.PersonPriority;
 import connectify.model.person.Phone;
 import connectify.model.tag.Tag;
 
@@ -131,5 +132,15 @@ public class ParserUtil {
         requireNonNull(s);
         String trimmedCompany = s.trim();
         return Index.fromOneBased(Integer.parseInt(trimmedCompany));
+    }
+
+    /**
+     * Parses a {@code String priority} into an {@code Priority}.
+     */
+
+    public static PersonPriority parsePersonPriority(String priority) throws ParseException {
+        requireNonNull(priority);
+        String trimmedPriority = priority.trim();
+        return new PersonPriority(trimmedPriority);
     }
 }

--- a/src/main/java/connectify/model/Priority.java
+++ b/src/main/java/connectify/model/Priority.java
@@ -1,0 +1,81 @@
+package connectify.model;
+
+import static java.util.Objects.requireNonNull;
+
+import connectify.commons.util.AppUtil;
+
+/**
+ * Represents a Priority in the Connectify.
+ */
+public abstract class Priority {
+
+    public static final String VALIDATION_REGEX = "^[0-9]+$";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Priority should only contain numbers, and it should be at least 1 digit long";
+
+    public final Integer value;
+
+    /**
+     * Constructor for Priority
+     * @param value a value for the priority
+     */
+    public Priority(String value) {
+        requireNonNull(value);
+        AppUtil.checkArgument(isValidPriority(value.toString()), MESSAGE_CONSTRAINTS);
+        this.value = Integer.parseInt(value);
+    }
+
+    /**
+     * Constructor for Priority
+     * @param value a value for the priority
+     */
+    public Priority(Integer value) {
+        requireNonNull(value);
+        this.value = value;
+    }
+
+    /**
+     * Returns the value of the priority
+     * @return the value of the priority
+     */
+    public Integer getValue() {
+        return value;
+    }
+
+    /**
+     * Returns true if a given string is a valid priority.
+     */
+    public static boolean isValidPriority(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    /**
+     * Returns the priority as a string
+     * @return the priority as a string
+     */
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Priority)) {
+            return false;
+        }
+
+        Priority otherWebsite = (Priority) other;
+        return value.equals(otherWebsite.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+}

--- a/src/main/java/connectify/model/person/Person.java
+++ b/src/main/java/connectify/model/person/Person.java
@@ -25,16 +25,19 @@ public class Person extends Entity {
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
 
+    private final PersonPriority priority;
+
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        CollectionUtil.requireAllNonNull(name, phone, email, address, tags);
+    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, PersonPriority priority) {
+        CollectionUtil.requireAllNonNull(name, phone, email, address, tags, priority);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.priority = priority;
     }
 
     public Name getName() {
@@ -51,6 +54,10 @@ public class Person extends Entity {
 
     public Address getAddress() {
         return address;
+    }
+
+    public PersonPriority getPriority() {
+        return priority;
     }
 
     /**
@@ -94,7 +101,9 @@ public class Person extends Entity {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags);
+                && tags.equals(otherPerson.tags)
+                && priority.equals(otherPerson.priority);
+
     }
 
     @Override
@@ -111,6 +120,7 @@ public class Person extends Entity {
                 .add("email", email)
                 .add("address", address)
                 .add("tags", tags)
+                .add("priority", priority)
                 .toString();
     }
 

--- a/src/main/java/connectify/model/person/PersonPriority.java
+++ b/src/main/java/connectify/model/person/PersonPriority.java
@@ -1,0 +1,22 @@
+package connectify.model.person;
+
+import connectify.model.Priority;
+
+/**
+ * A person's priority.
+ */
+public class PersonPriority extends Priority {
+
+    public PersonPriority(Integer value) {
+        super(value);
+    }
+
+    public PersonPriority(String value) {
+        super(value);
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+}

--- a/src/main/java/connectify/model/util/SampleDataUtil.java
+++ b/src/main/java/connectify/model/util/SampleDataUtil.java
@@ -11,6 +11,7 @@ import connectify.model.person.Address;
 import connectify.model.person.Email;
 import connectify.model.person.Name;
 import connectify.model.person.Person;
+import connectify.model.person.PersonPriority;
 import connectify.model.person.Phone;
 import connectify.model.tag.Tag;
 
@@ -22,22 +23,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
+                getTagSet("friends"), new PersonPriority("1")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends")),
+                getTagSet("colleagues", "friends"), new PersonPriority("2")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours")),
+                getTagSet("neighbours"), new PersonPriority("3")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family")),
+                getTagSet("family"), new PersonPriority("4")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates")),
+                getTagSet("classmates"), new PersonPriority("5")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"))
+                getTagSet("colleagues"), new PersonPriority("6")),
         };
     }
 

--- a/src/main/java/connectify/storage/JsonAdaptedPerson.java
+++ b/src/main/java/connectify/storage/JsonAdaptedPerson.java
@@ -14,6 +14,7 @@ import connectify.model.person.Address;
 import connectify.model.person.Email;
 import connectify.model.person.Name;
 import connectify.model.person.Person;
+import connectify.model.person.PersonPriority;
 import connectify.model.person.Phone;
 import connectify.model.tag.Tag;
 
@@ -30,13 +31,16 @@ class JsonAdaptedPerson {
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
+    private final String priority;
+
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
      */
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+            @JsonProperty("tags") List<JsonAdaptedTag> tags,
+            @JsonProperty("priority") String priority) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -44,6 +48,8 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
+        this.priority = priority;
+
     }
 
     /**
@@ -57,6 +63,7 @@ class JsonAdaptedPerson {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        priority = source.getPriority().toString();
     }
 
     /**
@@ -103,7 +110,14 @@ class JsonAdaptedPerson {
         final Address modelAddress = new Address(address);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+
+        if (priority == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT,
+                    PersonPriority.class.getSimpleName()));
+        }
+        final PersonPriority priority = new PersonPriority(this.priority);
+
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags, priority);
     }
 
 }

--- a/src/main/java/connectify/storage/JsonAddressBookStorage.java
+++ b/src/main/java/connectify/storage/JsonAddressBookStorage.java
@@ -47,6 +47,7 @@ public class JsonAddressBookStorage implements AddressBookStorage {
 
         Optional<JsonSerializableAddressBook> jsonAddressBook = JsonUtil.readJsonFile(
                 filePath, JsonSerializableAddressBook.class);
+
         if (!jsonAddressBook.isPresent()) {
             return Optional.empty();
         }

--- a/src/main/java/connectify/ui/CompanyCard.java
+++ b/src/main/java/connectify/ui/CompanyCard.java
@@ -50,8 +50,10 @@ public class CompanyCard extends UiPart<Region> {
 
         PersonList personList = company.getPersonList();
         StringBuilder str = new StringBuilder("People:\n");
+        int count = 0;
         for (Person person : personList) {
-            str.append(person.getName() + "\n");
+            str.append(count + 1).append(". ").append(person.getName()).append("\n");
+            count++;
         }
         people.setText(str.toString());
 

--- a/src/main/java/connectify/ui/PersonCard.java
+++ b/src/main/java/connectify/ui/PersonCard.java
@@ -49,8 +49,12 @@ public class PersonCard extends UiPart<Region> {
         phone.setText(person.getPhone().value);
         address.setText(person.getAddress().value);
         email.setText(person.getEmail().value);
+        Label label = new Label("Priority: " + person.getPriority().value);
+        label.setStyle("-fx-background-color: #588B8B");
+        tags.getChildren().add(label);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+
     }
 }

--- a/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/duplicatePersonAddressBook.json
@@ -4,11 +4,13 @@
     "phone": "94351253",
     "email": "alice@example.com",
     "address": "123, Jurong West Ave 6, #08-111",
-    "tags": [ "friends" ]
+    "tags": [ "friends" ],
+    "priority": "1"
   }, {
     "name": "Alice Pauline",
     "phone": "94351253",
     "email": "pauline@example.com",
-    "address": "4th street"
+    "address": "4th street",
+    "priority": "1"
   } ]
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,42 +5,49 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "tags" : [ "friends" ]
+    "tags" : [ "friends" ],
+    "priority" : "1"
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "tags" : [ "owesMoney", "friends" ]
+    "tags" : [ "owesMoney", "friends" ],
+    "priority" : "2"
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "tags" : [ ]
+    "tags" : [ ],
+    "priority" : "3"
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
-    "tags" : [ "friends" ]
+    "tags" : [ "friends" ],
+    "priority" : "4"
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
-    "tags" : [ ]
+    "tags" : [ ],
+    "priority" : "5"
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
-    "tags" : [ ]
+    "tags" : [ ],
+    "priority" : "6"
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
-    "tags" : [ ]
+    "tags" : [ ],
+    "priority" : "7"
   } ]
 }

--- a/src/test/java/connectify/logic/LogicManagerTest.java
+++ b/src/test/java/connectify/logic/LogicManagerTest.java
@@ -180,7 +180,8 @@ public class LogicManagerTest {
         // Triggers the saveAddressBook method by executing an add command
         String addPersonCommand = AddPersonCommand.COMMAND_WORD
                 + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
-                + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY;
+                + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY
+                + CommandTestUtil.PRIORITY_DESC_AMY;
         Person expectedPerson = new PersonBuilder(TypicalPersons.AMY).withTags().build();
 
         ModelManager expectedModel = new ModelManager();

--- a/src/test/java/connectify/logic/commands/CommandTestUtil.java
+++ b/src/test/java/connectify/logic/commands/CommandTestUtil.java
@@ -4,6 +4,7 @@ import static connectify.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static connectify.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connectify.logic.parser.CliSyntax.PREFIX_NAME;
 import static connectify.logic.parser.CliSyntax.PREFIX_PHONE;
+import static connectify.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static connectify.logic.parser.CliSyntax.PREFIX_TAG;
 import static connectify.testutil.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,6 +39,9 @@ public class CommandTestUtil {
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
+    public static final String VALID_PRIORITY_AMY = "10";
+    public static final String VALID_PRIORITY_BOB = "5";
+
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
     public static final String PHONE_DESC_AMY = " " + PREFIX_PHONE + VALID_PHONE_AMY;
@@ -46,6 +50,9 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
+
+    public static final String PRIORITY_DESC_AMY = " " + PREFIX_PRIORITY + VALID_PRIORITY_AMY;
+    public static final String PRIORITY_DESC_BOB = " " + PREFIX_PRIORITY + VALID_PRIORITY_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -54,6 +61,8 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+
+    public static final String INVALID_PRIORITY_DESC = " " + PREFIX_PRIORITY + "abc"; // priority must be an integer
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/connectify/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/connectify/logic/commands/EditPersonDescriptorTest.java
@@ -65,7 +65,8 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
                 + editPersonDescriptor.getAddress().orElse(null) + ", tags="
-                + editPersonDescriptor.getTags().orElse(null) + "}";
+                + editPersonDescriptor.getTags().orElse(null) + ", priority="
+                + editPersonDescriptor.getPersonPriority().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/connectify/logic/parser/AddPersonCommandParserTest.java
+++ b/src/test/java/connectify/logic/parser/AddPersonCommandParserTest.java
@@ -32,7 +32,8 @@ public class AddPersonCommandParserTest {
         // whitespace only preamble
         CommandParserTestUtil.assertParseSuccess(parser, CommandTestUtil.PREAMBLE_WHITESPACE
                     + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
-                    + CommandTestUtil.ADDRESS_DESC_BOB + CommandTestUtil.TAG_DESC_FRIEND,
+                    + CommandTestUtil.ADDRESS_DESC_BOB + CommandTestUtil.TAG_DESC_FRIEND
+                        + CommandTestUtil.PRIORITY_DESC_BOB,
                     new AddPersonCommand(expectedPerson, INDEX_FIRST_COMPANY));
 
 
@@ -42,15 +43,15 @@ public class AddPersonCommandParserTest {
         CommandParserTestUtil.assertParseSuccess(parser,
             CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                     + CommandTestUtil.ADDRESS_DESC_BOB + CommandTestUtil.TAG_DESC_HUSBAND
-                    + CommandTestUtil.TAG_DESC_FRIEND, new AddPersonCommand(expectedPersonMultipleTags,
-                        INDEX_FIRST_COMPANY));
+                    + CommandTestUtil.TAG_DESC_FRIEND + CommandTestUtil.PRIORITY_DESC_BOB,
+                new AddPersonCommand(expectedPersonMultipleTags, INDEX_FIRST_COMPANY));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPersonString = CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
                     + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
-                    + CommandTestUtil.TAG_DESC_FRIEND;
+                    + CommandTestUtil.TAG_DESC_FRIEND + CommandTestUtil.PRIORITY_DESC_BOB;
 
         // multiple names
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.NAME_DESC_AMY
@@ -119,7 +120,8 @@ public class AddPersonCommandParserTest {
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         CommandParserTestUtil.assertParseSuccess(parser, CommandTestUtil.NAME_DESC_AMY
                     + CommandTestUtil.PHONE_DESC_AMY + CommandTestUtil.EMAIL_DESC_AMY
-                    + CommandTestUtil.ADDRESS_DESC_AMY, new AddPersonCommand(expectedPerson, INDEX_FIRST_COMPANY));
+                    + CommandTestUtil.ADDRESS_DESC_AMY + CommandTestUtil.PRIORITY_DESC_AMY,
+                new AddPersonCommand(expectedPerson, INDEX_FIRST_COMPANY));
     }
 
     @Test
@@ -157,41 +159,48 @@ public class AddPersonCommandParserTest {
         // invalid name
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.INVALID_NAME_DESC
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
-                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
+                + CommandTestUtil.PRIORITY_DESC_BOB + CommandTestUtil.PRIORITY_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.NAME_DESC_BOB
                 + CommandTestUtil.INVALID_PHONE_DESC + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.ADDRESS_DESC_BOB
-                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
+                + CommandTestUtil.PRIORITY_DESC_BOB, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.NAME_DESC_BOB
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.INVALID_EMAIL_DESC
                 + CommandTestUtil.ADDRESS_DESC_BOB
-                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
+                + CommandTestUtil.PRIORITY_DESC_BOB, Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.NAME_DESC_BOB
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.INVALID_ADDRESS_DESC
-                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
+                + CommandTestUtil.PRIORITY_DESC_BOB, Address.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.NAME_DESC_BOB
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
-                + CommandTestUtil.INVALID_TAG_DESC + CommandTestUtil.VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.INVALID_TAG_DESC + CommandTestUtil.VALID_TAG_FRIEND
+                + CommandTestUtil.PRIORITY_DESC_BOB, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.INVALID_NAME_DESC
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
-                + CommandTestUtil.INVALID_ADDRESS_DESC, Name.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.INVALID_ADDRESS_DESC
+                + CommandTestUtil.PRIORITY_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.PREAMBLE_NON_EMPTY
                 + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
                 + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
-                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND,
+                + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
+                + CommandTestUtil.PRIORITY_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
+++ b/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
@@ -3,6 +3,7 @@ package connectify.logic.parser;
 import static connectify.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connectify.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static connectify.logic.parser.CliSyntax.PREFIX_COMPANY;
+import static connectify.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static connectify.testutil.Assert.assertThrows;
 import static connectify.testutil.TypicalIndexes.INDEX_FIRST_COMPANY;
 import static connectify.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -85,7 +86,7 @@ public class ConnectifyParserTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditPersonCommand command = (EditPersonCommand) parser.parseCommand(EditPersonCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PREFIX_COMPANY
-                + INDEX_FIRST_COMPANY.getOneBased() + " "
+                + INDEX_FIRST_COMPANY.getOneBased() + " " + PREFIX_PRIORITY + "1 "
                 + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditPersonCommand(INDEX_FIRST_PERSON, INDEX_FIRST_COMPANY, descriptor), command);
     }

--- a/src/test/java/connectify/logic/parser/EditPersonCommandParserTest.java
+++ b/src/test/java/connectify/logic/parser/EditPersonCommandParserTest.java
@@ -116,16 +116,18 @@ public class EditPersonCommandParserTest {
         String userInput = targetIndex.getOneBased() + " " + PREFIX_COMPANY + INDEX_FIRST_COMPANY.getOneBased()
                 + CommandTestUtil.PHONE_DESC_BOB
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY
-                + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.TAG_DESC_FRIEND;
+                + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.TAG_DESC_FRIEND + CommandTestUtil.PRIORITY_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(CommandTestUtil.VALID_NAME_AMY)
                 .withPhone(CommandTestUtil.VALID_PHONE_BOB).withEmail(CommandTestUtil.VALID_EMAIL_AMY)
                 .withAddress(CommandTestUtil.VALID_ADDRESS_AMY).withTags(CommandTestUtil.VALID_TAG_HUSBAND,
-                        CommandTestUtil.VALID_TAG_FRIEND).build();
+                        CommandTestUtil.VALID_TAG_FRIEND)
+                .withPersonPriority(CommandTestUtil.VALID_PRIORITY_AMY).build();
         EditPersonCommand expectedCommand = new EditPersonCommand(targetIndex, INDEX_FIRST_COMPANY, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
+
 
     @Test
     public void parse_someFieldsSpecified_success() {

--- a/src/test/java/connectify/model/person/PersonPriorityTest.java
+++ b/src/test/java/connectify/model/person/PersonPriorityTest.java
@@ -49,6 +49,12 @@ public class PersonPriorityTest {
     }
 
     @Test
+    public void toStringTest() {
+        PersonPriority priority = new PersonPriority("1");
+        assertTrue(priority.toString().equals("1"));
+    }
+
+    @Test
     public void equals() {
         PersonPriority priority = new PersonPriority("1");
 

--- a/src/test/java/connectify/model/person/PersonPriorityTest.java
+++ b/src/test/java/connectify/model/person/PersonPriorityTest.java
@@ -1,0 +1,73 @@
+package connectify.model.person;
+
+import static connectify.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class PersonPriorityTest {
+
+    @Test
+    public void constructor_integerValue_success() {
+        PersonPriority priority = new PersonPriority(1);
+        assertTrue(priority.equals(new PersonPriority("1")));
+    }
+
+    @Test
+    public void constructor_stringValue_success() {
+        PersonPriority priority = new PersonPriority("1");
+        assertTrue(priority.equals(new PersonPriority(1)));
+    }
+
+    @Test
+    public void constructor_invalidPriority_throwsIllegalArgumentException() {
+        String invalidPriority = "abc";
+        assertThrows(IllegalArgumentException.class, () -> new PersonPriority(invalidPriority));
+    }
+
+    @Test
+    public void isValidPriority() {
+        // null priority
+        assertThrows(NullPointerException.class, () -> PersonPriority.isValidPriority(null));
+
+        // invalid priority
+        assertFalse(PersonPriority.isValidPriority("")); // empty string
+        assertFalse(PersonPriority.isValidPriority(" ")); // spaces only
+        assertFalse(PersonPriority.isValidPriority("abc")); // alphabets only
+        assertFalse(PersonPriority.isValidPriority("123abc")); // numbers and alphabets
+        assertFalse(PersonPriority.isValidPriority("abc123")); // alphabets and numbers
+        assertFalse(PersonPriority.isValidPriority("123 abc")); // numbers and alphabets with spaces
+        assertFalse(PersonPriority.isValidPriority("abc 123")); // alphabets and numbers with spaces
+        assertFalse(PersonPriority.isValidPriority("123 abc 123")); // numbers and alphabets with spaces
+
+        // valid priority
+        assertTrue(PersonPriority.isValidPriority("1")); // single digit
+        assertTrue(PersonPriority.isValidPriority("10")); // double digit
+        assertTrue(PersonPriority.isValidPriority("100")); // triple digit
+        assertTrue(PersonPriority.isValidPriority("1000")); // quadruple digit
+    }
+
+    @Test
+    public void equals() {
+        PersonPriority priority = new PersonPriority("1");
+
+        // same values -> returns true
+        assertTrue(priority.equals(new PersonPriority("1")));
+
+        // same object -> returns true
+        assertTrue(priority.equals(priority));
+
+        // null -> returns false
+        assertFalse(priority.equals(null));
+
+        // different types -> returns false
+        assertFalse(priority.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(priority.equals(new PersonPriority("2")));
+    }
+
+
+
+}

--- a/src/test/java/connectify/model/person/PersonTest.java
+++ b/src/test/java/connectify/model/person/PersonTest.java
@@ -93,7 +93,8 @@ public class PersonTest {
     @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
+                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
+                + ", priority=" + ALICE.getPriority() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/connectify/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/connectify/storage/JsonAdaptedPersonTest.java
@@ -28,6 +28,8 @@ public class JsonAdaptedPersonTest {
     private static final String VALID_PHONE = TypicalPersons.BENSON.getPhone().toString();
     private static final String VALID_EMAIL = TypicalPersons.BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = TypicalPersons.BENSON.getAddress().toString();
+
+    private static final String VALID_PRIORITY = TypicalPersons.BENSON.getPriority().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = TypicalPersons.BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
@@ -41,14 +43,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -56,14 +60,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
+                        VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
+                VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -71,14 +77,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
+                        VALID_TAGS, VALID_PRIORITY);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS,
+                VALID_PRIORITY);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,14 +94,16 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS,
+                        VALID_PRIORITY);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS,
+                VALID_PRIORITY);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         Assert.assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,7 +113,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags,
+                        VALID_PRIORITY);
         Assert.assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/connectify/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/connectify/testutil/EditPersonDescriptorBuilder.java
@@ -9,6 +9,7 @@ import connectify.model.person.Address;
 import connectify.model.person.Email;
 import connectify.model.person.Name;
 import connectify.model.person.Person;
+import connectify.model.person.PersonPriority;
 import connectify.model.person.Phone;
 import connectify.model.tag.Tag;
 
@@ -37,6 +38,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setEmail(person.getEmail());
         descriptor.setAddress(person.getAddress());
         descriptor.setTags(person.getTags());
+        descriptor.setPersonPriority(person.getPriority());
     }
 
     /**
@@ -78,6 +80,17 @@ public class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder withTags(String... tags) {
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
+        return this;
+    }
+
+    /**
+     * Sets the {@code PersonPriority} of the {@code EditPersonDescriptor} that we are building.
+     * @return
+     */
+
+    public EditPersonDescriptorBuilder withPersonPriority(String priority) {
+        PersonPriority converted = new PersonPriority(priority);
+        descriptor.setPersonPriority(converted);
         return this;
     }
 

--- a/src/test/java/connectify/testutil/PersonBuilder.java
+++ b/src/test/java/connectify/testutil/PersonBuilder.java
@@ -7,6 +7,7 @@ import connectify.model.person.Address;
 import connectify.model.person.Email;
 import connectify.model.person.Name;
 import connectify.model.person.Person;
+import connectify.model.person.PersonPriority;
 import connectify.model.person.Phone;
 import connectify.model.tag.Tag;
 import connectify.model.util.SampleDataUtil;
@@ -21,11 +22,15 @@ public class PersonBuilder {
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
 
+    public static final String DEFAULT_PRIORITY = "1";
+
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
     private Set<Tag> tags;
+
+    private PersonPriority priority;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -36,6 +41,8 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
+        priority = new PersonPriority(DEFAULT_PRIORITY);
+
     }
 
     /**
@@ -47,6 +54,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
+        priority = personToCopy.getPriority();
     }
 
     /**
@@ -90,11 +98,19 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code Priority} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withPriority(String priority) {
+        this.priority = new PersonPriority(priority);
+        return this;
+    }
+
+    /**
      * Builds a person object.
      * @return Person object
      */
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, tags, priority);
     }
 
 }

--- a/src/test/java/connectify/testutil/PersonUtil.java
+++ b/src/test/java/connectify/testutil/PersonUtil.java
@@ -4,6 +4,7 @@ import static connectify.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static connectify.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connectify.logic.parser.CliSyntax.PREFIX_NAME;
 import static connectify.logic.parser.CliSyntax.PREFIX_PHONE;
+import static connectify.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static connectify.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -34,6 +35,7 @@ public class PersonUtil {
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
+        sb.append(PREFIX_PRIORITY + person.getPriority().toString() + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );

--- a/src/test/java/connectify/testutil/TypicalPersons.java
+++ b/src/test/java/connectify/testutil/TypicalPersons.java
@@ -17,36 +17,39 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
             .withPhone("94351253")
-            .withTags("friends").build();
+            .withTags("friends")
+            .withPriority("1")
+            .build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").build();
+            .withTags("owesMoney", "friends").withPriority("2").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com").withAddress("wall street").withPriority("3").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
+            .withEmail("cornelia@example.com").withAddress("10th street").withPriority("4").withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").build();
+            .withEmail("werner@example.com").withAddress("michegan ave").withPriority("5").build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").build();
+            .withEmail("lydia@example.com").withAddress("little tokyo").withPriority("6").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").build();
+            .withEmail("anna@example.com").withAddress("4th street").withPriority("7").build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india").build();
+            .withEmail("stefan@example.com").withAddress("little india").withPriority("7").build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").build();
+            .withEmail("hans@example.com").withAddress("chicago ave").withPriority("8").build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(CommandTestUtil.VALID_NAME_AMY)
             .withPhone(CommandTestUtil.VALID_PHONE_AMY).withEmail(CommandTestUtil.VALID_EMAIL_AMY)
-            .withAddress(CommandTestUtil.VALID_ADDRESS_AMY).withTags(CommandTestUtil.VALID_TAG_FRIEND).build();
+            .withAddress(CommandTestUtil.VALID_ADDRESS_AMY).withTags(CommandTestUtil.VALID_TAG_FRIEND)
+            .withPriority(CommandTestUtil.VALID_PRIORITY_AMY).build();
     public static final Person BOB = new PersonBuilder().withName(CommandTestUtil.VALID_NAME_BOB)
             .withPhone(CommandTestUtil.VALID_PHONE_BOB).withEmail(CommandTestUtil.VALID_EMAIL_BOB)
             .withAddress(CommandTestUtil.VALID_ADDRESS_BOB).withTags(CommandTestUtil.VALID_TAG_HUSBAND,
-                    CommandTestUtil.VALID_TAG_FRIEND).build();
+                    CommandTestUtil.VALID_TAG_FRIEND).withPriority(CommandTestUtil.VALID_PRIORITY_BOB).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 


### PR DESCRIPTION
This PR fixes #80, adding a PersonPriority to each Person object. The implementation is done by creating a Priority abstract class. 

Notes about implementation:
- Priority is implemented as a compulsory input field for both AddPerson and EditPerson as it is a core functionality of Connectify 
- Both AddPersonnd EditPerson commands have been updated to support priority 

The UI has also been updated to display the priority as a tag.