### PR TITLE
Fix notePerson and addPerson command

### DIFF
--- a/src/main/java/connectify/logic/Messages.java
+++ b/src/main/java/connectify/logic/Messages.java
@@ -49,7 +49,7 @@ public class Messages {
                 .append(person.getAddress())
                 .append("; Note: ")
                 .append(person.getNote())
-                .append("Priority: ")
+                .append("; Priority: ")
                 .append(person.getPriority())
                 .append("; Company: ");
         if (person.getParentCompany() != null) {

--- a/src/main/java/connectify/logic/commands/AddPersonCommand.java
+++ b/src/main/java/connectify/logic/commands/AddPersonCommand.java
@@ -32,18 +32,18 @@ public class AddPersonCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_COMPANY + "COMPANY_INDEX "
+            + PREFIX_PRIORITY + "PRIORITY "
             + "[" + PREFIX_TAG + "TAG]...\n"
-            + "[" + PREFIX_COMPANY + "COMPANY_INDEX]...\n"
-            + "[" + PREFIX_PRIORITY + "PRIORITY]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney "
             + PREFIX_COMPANY + "1 "
-            + PREFIX_PRIORITY + "1";
+            + PREFIX_PRIORITY + "1 "
+            + PREFIX_TAG + "friends "
+            + PREFIX_TAG + "owesMoney";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/connectify/logic/commands/PersonNoteCommand.java
+++ b/src/main/java/connectify/logic/commands/PersonNoteCommand.java
@@ -82,7 +82,7 @@ public class PersonNoteCommand extends Command {
      */
     private String generateSuccessMessage(Person personToEdit) {
         String message = !note.getContent().isEmpty() ? MESSAGE_ADD_NOTE_SUCCESS : MESSAGE_DELETE_NOTE_SUCCESS;
-        return String.format(message, personToEdit);
+        return String.format(message, Messages.format(personToEdit));
     }
 
     @Override

--- a/src/main/java/connectify/logic/parser/AddPersonCommandParser.java
+++ b/src/main/java/connectify/logic/parser/AddPersonCommandParser.java
@@ -34,13 +34,13 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
                         CliSyntax.PREFIX_COMPANY, CliSyntax.PREFIX_PRIORITY);
 
         if (!arePrefixesPresent(argMultimap, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_ADDRESS,
-                CliSyntax.PREFIX_PHONE, CliSyntax.PREFIX_EMAIL, CliSyntax.PREFIX_PRIORITY)
+                CliSyntax.PREFIX_PHONE, CliSyntax.PREFIX_EMAIL, CliSyntax.PREFIX_PRIORITY, CliSyntax.PREFIX_COMPANY)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_PHONE, CliSyntax.PREFIX_EMAIL,
-                CliSyntax.PREFIX_ADDRESS);
+                CliSyntax.PREFIX_ADDRESS, CliSyntax.PREFIX_COMPANY, CliSyntax.PREFIX_PRIORITY);
         PersonName name = ParserPersonUtil.parseName(argMultimap.getValue(CliSyntax.PREFIX_NAME).get());
         PersonPhone personPhone = ParserPersonUtil.parsePhone(argMultimap.getValue(CliSyntax.PREFIX_PHONE).get());
         PersonEmail personEmail = ParserPersonUtil.parseEmail(argMultimap.getValue(CliSyntax.PREFIX_EMAIL).get());
@@ -50,8 +50,7 @@ public class AddPersonCommandParser implements Parser<AddPersonCommand> {
         Set<Tag> tagList = ParserPersonUtil.parseTags(argMultimap.getAllValues(CliSyntax.PREFIX_TAG));
 
         // Defaults to first company if no company index is provided
-        Index companyIndex = ParserCompanyUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_COMPANY)
-                .orElse("1"));
+        Index companyIndex = ParserCompanyUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_COMPANY).get());
         PersonPriority priority = ParserPersonUtil
             .parsePersonPriority(argMultimap.getValue(CliSyntax.PREFIX_PRIORITY).get());
         Person person = new Person(name, personPhone, personEmail, personAddress, tagList, note, priority);

--- a/src/main/java/connectify/logic/parser/PersonNoteCommandParser.java
+++ b/src/main/java/connectify/logic/parser/PersonNoteCommandParser.java
@@ -6,9 +6,12 @@ import static java.util.Objects.requireNonNull;
 
 import connectify.commons.core.index.Index;
 import connectify.commons.exceptions.IllegalValueException;
+import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.PersonNoteCommand;
 import connectify.logic.parser.exceptions.ParseException;
 import connectify.model.person.PersonNote;
+
+import java.util.stream.Stream;
 
 /**
  * Parses input arguments and creates a new {@code NoteCommand} object
@@ -22,6 +25,8 @@ public class PersonNoteCommandParser implements Parser<PersonNoteCommand> {
     public PersonNoteCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NOTE);
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NOTE);
 
         try {
             String[] splitArgs = args.trim().split("\\s+");
@@ -40,5 +45,13 @@ public class PersonNoteCommandParser implements Parser<PersonNoteCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     PersonNoteCommand.MESSAGE_USAGE), ive);
         }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/connectify/logic/parser/PersonNoteCommandParser.java
+++ b/src/main/java/connectify/logic/parser/PersonNoteCommandParser.java
@@ -46,12 +46,4 @@ public class PersonNoteCommandParser implements Parser<PersonNoteCommand> {
                     PersonNoteCommand.MESSAGE_USAGE), ive);
         }
     }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
 }

--- a/src/main/java/connectify/logic/parser/PersonNoteCommandParser.java
+++ b/src/main/java/connectify/logic/parser/PersonNoteCommandParser.java
@@ -6,12 +6,9 @@ import static java.util.Objects.requireNonNull;
 
 import connectify.commons.core.index.Index;
 import connectify.commons.exceptions.IllegalValueException;
-import connectify.logic.commands.AddPersonCommand;
 import connectify.logic.commands.PersonNoteCommand;
 import connectify.logic.parser.exceptions.ParseException;
 import connectify.model.person.PersonNote;
-
-import java.util.stream.Stream;
 
 /**
  * Parses input arguments and creates a new {@code NoteCommand} object

--- a/src/main/java/connectify/ui/EntityListPanel.java
+++ b/src/main/java/connectify/ui/EntityListPanel.java
@@ -108,7 +108,7 @@ public class EntityListPanel extends UiPart<Region> {
         infoBox.setSpacing(5); // Spacing between each label and value
         infoBox.setPadding(new Insets(10, 10, 10, 10)); // Padding around the entire infoBox
 
-        infoBox.getChildren().add( new Label("Industry: " + company.getIndustry()));
+        infoBox.getChildren().add(new Label("Industry: " + company.getIndustry()));
         infoBox.getChildren().add(new Label("Location: " + company.getLocation()));
         infoBox.getChildren().add(new Label("Website: " + company.getWebsite()));
         infoBox.getChildren().add(new Label("Email: " + company.getEmail()));

--- a/src/test/java/connectify/logic/LogicManagerTest.java
+++ b/src/test/java/connectify/logic/LogicManagerTest.java
@@ -203,18 +203,18 @@ public class LogicManagerTest {
                 new JsonUserPrefsStorage(temporaryFolder.resolve("ExceptionUserPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
 
-        model.addCompany(TypicalCompanies.DUMMY_COMPANY); // To be removed in future
+        model.addCompany(TypicalCompanies.COMPANY_1);
         logic = new LogicManager(model, storage);
 
         // Triggers the saveAddressBook method by executing an add command
         String addPersonCommand = AddPersonCommand.COMMAND_WORD
                 + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.PHONE_DESC_AMY
                 + CommandTestUtil.EMAIL_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY
-                + CommandTestUtil.PRIORITY_DESC_AMY;
+                + CommandTestUtil.COMPANY_DESC_AMY + CommandTestUtil.PRIORITY_DESC_AMY;
         Person expectedPerson = new PersonBuilder(TypicalPersons.AMY).withTags().build();
 
         ModelManager expectedModel = new ModelManager();
-        expectedModel.addCompany(TypicalCompanies.DUMMY_COMPANY); // To be removed in future
+        expectedModel.addCompany(TypicalCompanies.COMPANY_1);
 
         List<Company> companies = expectedModel.getFilteredCompanyList();
         Company targetCompany = companies.get(INDEX_FIRST_COMPANY.getZeroBased());

--- a/src/test/java/connectify/logic/commands/CommandTestUtil.java
+++ b/src/test/java/connectify/logic/commands/CommandTestUtil.java
@@ -1,6 +1,7 @@
 package connectify.logic.commands;
 
 import static connectify.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static connectify.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static connectify.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connectify.logic.parser.CliSyntax.PREFIX_NAME;
 import static connectify.logic.parser.CliSyntax.PREFIX_NOTE;
@@ -59,12 +60,13 @@ public class CommandTestUtil {
 
     public static final String PRIORITY_DESC_AMY = " " + PREFIX_PRIORITY + VALID_PRIORITY_AMY;
     public static final String PRIORITY_DESC_BOB = " " + PREFIX_PRIORITY + VALID_PRIORITY_BOB;
+
+    public static final String COMPANY_DESC_AMY = " " + PREFIX_COMPANY + "1";
+    public static final String COMPANY_DESC_BOB = " " + PREFIX_COMPANY + "2";
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
     public static final String NOTE_DESC_AMY = " " + PREFIX_NOTE + VALID_NOTE_AMY;
-    public static final String NOTE_DESC_BOB = " " + PREFIX_NOTE + VALID_NOTE_BOB;
-
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/connectify/logic/commands/PersonNoteCommandTest.java
+++ b/src/test/java/connectify/logic/commands/PersonNoteCommandTest.java
@@ -35,15 +35,15 @@ public class PersonNoteCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_addNoteUnfilteredList_success() {
+    public void execute_addNote_success() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(firstPerson).withNote(NOTE_STUB)
-                                            .withParentCompany(firstPerson.getParentCompany()).build();
+        Person editedPerson = new PersonBuilder(firstPerson).withNote(NOTE_STUB).build();
 
         PersonNoteCommand personNoteCommand = new PersonNoteCommand(INDEX_FIRST_COMPANY, INDEX_FIRST_PERSON,
                 new PersonNote(editedPerson.getNote().getContent()));
 
-        String expectedMessage = String.format(PersonNoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedPerson);
+        String expectedMessage = String.format(PersonNoteCommand.MESSAGE_ADD_NOTE_SUCCESS,
+                Messages.format(editedPerson));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(firstPerson, editedPerson);
@@ -56,63 +56,29 @@ public class PersonNoteCommandTest {
     }
 
     @Test
-    public void execute_deleteNoteUnfilteredList_success() {
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(firstPerson).withNote("").build();
+    public void execute_deleteNote_success() {
+        Person personWithoutNote = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        Person editedPersonWithNote = new PersonBuilder(personWithoutNote).withNote(NOTE_STUB).build();
+        System.out.println(Messages.format(editedPersonWithNote));
 
         PersonNoteCommand personNoteCommand = new PersonNoteCommand(INDEX_FIRST_COMPANY, INDEX_FIRST_PERSON,
-                new PersonNote(editedPerson.getNote().toString()));
+                new PersonNote("")); // Empty note object to delete existing note
 
-        String expectedMessage = String.format(PersonNoteCommand.MESSAGE_DELETE_NOTE_SUCCESS, editedPerson);
+        String expectedMessage = String.format(PersonNoteCommand.MESSAGE_DELETE_NOTE_SUCCESS,
+                Messages.format(personWithoutNote));
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(firstPerson, editedPerson);
 
-        Company expectedCompanyToUpdate = expectedModel.getFilteredCompanyList()
+        model.setPerson(personWithoutNote, editedPersonWithNote); // Update current model with person with note
+
+        Company expectedCompanyToUpdate = model.getFilteredCompanyList()
                 .get(INDEX_FIRST_COMPANY.getZeroBased());
-        Company editedCompany = expectedCompanyToUpdate.setPerson(firstPerson, editedPerson);
-        expectedModel.setCompany(expectedCompanyToUpdate, editedCompany);
+        Company editedCompany = expectedCompanyToUpdate.setPerson(personWithoutNote, editedPersonWithNote);
+        model.setCompany(expectedCompanyToUpdate, editedCompany);
 
         assertCommandSuccess(personNoteCommand, model, expectedMessage, expectedModel);
     }
 
-    @Test
-    public void execute_filteredList_success() {
-        showPersonAtIndex(model, INDEX_FIRST_PERSON);
-
-        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        Person editedPerson = new PersonBuilder(model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased()))
-                .withNote(NOTE_STUB).build();
-
-        PersonNoteCommand personNoteCommand = new PersonNoteCommand(INDEX_FIRST_COMPANY, INDEX_FIRST_PERSON,
-                new PersonNote(editedPerson.getNote().getContent()));
-
-        String expectedMessage = String.format(PersonNoteCommand.MESSAGE_ADD_NOTE_SUCCESS, editedPerson);
-
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setPerson(firstPerson, editedPerson);
-
-        Company expectedCompanyToUpdate = expectedModel.getFilteredCompanyList()
-                .get(INDEX_FIRST_COMPANY.getZeroBased());
-        Company editedCompany = expectedCompanyToUpdate.setPerson(firstPerson, editedPerson);
-        expectedModel.setCompany(expectedCompanyToUpdate, editedCompany);
-
-        assertCommandSuccess(personNoteCommand, model, expectedMessage, expectedModel);
-    }
-
-    @Test
-    public void execute_invalidPersonIndexUnfilteredList_failure() {
-        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
-        PersonNoteCommand personNoteCommand = new PersonNoteCommand(INDEX_FIRST_COMPANY, outOfBoundIndex,
-                new PersonNote(VALID_NOTE_BOB));
-
-        assertCommandFailure(personNoteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-    }
-
-    /**
-     * Edit filtered list where the index is larger than the size of the filtered list,
-     * but smaller than the size of the address book.
-     */
     @Test
     public void execute_invalidPersonIndexFilteredList_failure() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);

--- a/src/test/java/connectify/logic/parser/AddPersonCommandParserTest.java
+++ b/src/test/java/connectify/logic/parser/AddPersonCommandParserTest.java
@@ -2,9 +2,11 @@ package connectify.logic.parser;
 
 import static connectify.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static connectify.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static connectify.logic.parser.CliSyntax.PREFIX_COMPANY;
 import static connectify.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static connectify.logic.parser.CliSyntax.PREFIX_NAME;
 import static connectify.logic.parser.CliSyntax.PREFIX_PHONE;
+import static connectify.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static connectify.testutil.TypicalIndexes.INDEX_FIRST_COMPANY;
 import static connectify.testutil.TypicalPersons.AMY;
 import static connectify.testutil.TypicalPersons.BOB;
@@ -33,7 +35,7 @@ public class AddPersonCommandParserTest {
         CommandParserTestUtil.assertParseSuccess(parser, CommandTestUtil.PREAMBLE_WHITESPACE
                     + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                     + CommandTestUtil.ADDRESS_DESC_BOB + CommandTestUtil.TAG_DESC_FRIEND
-                        + CommandTestUtil.PRIORITY_DESC_BOB,
+                    + CommandTestUtil.COMPANY_DESC_BOB + CommandTestUtil.PRIORITY_DESC_BOB,
                     new AddPersonCommand(expectedPerson, INDEX_FIRST_COMPANY));
 
 
@@ -43,7 +45,8 @@ public class AddPersonCommandParserTest {
         CommandParserTestUtil.assertParseSuccess(parser,
             CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                     + CommandTestUtil.ADDRESS_DESC_BOB + CommandTestUtil.TAG_DESC_HUSBAND
-                    + CommandTestUtil.TAG_DESC_FRIEND + CommandTestUtil.PRIORITY_DESC_BOB,
+                    + CommandTestUtil.TAG_DESC_FRIEND + CommandTestUtil.COMPANY_DESC_BOB
+                    + CommandTestUtil.PRIORITY_DESC_BOB,
                 new AddPersonCommand(expectedPersonMultipleTags, INDEX_FIRST_COMPANY));
     }
 
@@ -51,7 +54,8 @@ public class AddPersonCommandParserTest {
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPersonString = CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
                     + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
-                    + CommandTestUtil.TAG_DESC_FRIEND + CommandTestUtil.PRIORITY_DESC_BOB;
+                    + CommandTestUtil.TAG_DESC_FRIEND + CommandTestUtil.COMPANY_DESC_BOB
+                    + CommandTestUtil.PRIORITY_DESC_BOB;
 
         // multiple names
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.NAME_DESC_AMY
@@ -74,7 +78,7 @@ public class AddPersonCommandParserTest {
             validExpectedPersonString + CommandTestUtil.PHONE_DESC_AMY + CommandTestUtil.EMAIL_DESC_AMY
                     + CommandTestUtil.NAME_DESC_AMY + CommandTestUtil.ADDRESS_DESC_AMY + validExpectedPersonString,
                     Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NAME, PREFIX_ADDRESS,
-                            PREFIX_EMAIL, PREFIX_PHONE));
+                            PREFIX_EMAIL, PREFIX_PHONE, PREFIX_COMPANY, PREFIX_PRIORITY));
 
         // invalid value followed by valid value
 
@@ -120,7 +124,8 @@ public class AddPersonCommandParserTest {
         Person expectedPerson = new PersonBuilder(AMY).withTags().build();
         CommandParserTestUtil.assertParseSuccess(parser, CommandTestUtil.NAME_DESC_AMY
                     + CommandTestUtil.PHONE_DESC_AMY + CommandTestUtil.EMAIL_DESC_AMY
-                    + CommandTestUtil.ADDRESS_DESC_AMY + CommandTestUtil.PRIORITY_DESC_AMY,
+                    + CommandTestUtil.ADDRESS_DESC_AMY + CommandTestUtil.COMPANY_DESC_AMY
+                    + CommandTestUtil.PRIORITY_DESC_AMY,
                 new AddPersonCommand(expectedPerson, INDEX_FIRST_COMPANY));
     }
 
@@ -160,7 +165,7 @@ public class AddPersonCommandParserTest {
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.INVALID_NAME_DESC
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
-                + CommandTestUtil.PRIORITY_DESC_BOB + CommandTestUtil.PRIORITY_DESC_BOB,
+                + CommandTestUtil.PRIORITY_DESC_BOB + CommandTestUtil.COMPANY_DESC_BOB,
                 PersonName.MESSAGE_CONSTRAINTS);
 
         // invalid phone
@@ -168,40 +173,45 @@ public class AddPersonCommandParserTest {
                 + CommandTestUtil.INVALID_PHONE_DESC + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.ADDRESS_DESC_BOB
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
-                + CommandTestUtil.PRIORITY_DESC_BOB, PersonPhone.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.PRIORITY_DESC_BOB + CommandTestUtil.COMPANY_DESC_BOB,
+                PersonPhone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.NAME_DESC_BOB
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.INVALID_EMAIL_DESC
                 + CommandTestUtil.ADDRESS_DESC_BOB
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
-                + CommandTestUtil.PRIORITY_DESC_BOB, PersonEmail.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.PRIORITY_DESC_BOB + CommandTestUtil.COMPANY_DESC_BOB,
+                PersonEmail.MESSAGE_CONSTRAINTS);
 
         // invalid address
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.NAME_DESC_BOB
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.INVALID_ADDRESS_DESC
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
-                + CommandTestUtil.PRIORITY_DESC_BOB, PersonAddress.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.PRIORITY_DESC_BOB + CommandTestUtil.COMPANY_DESC_BOB,
+                PersonAddress.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.NAME_DESC_BOB
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
                 + CommandTestUtil.INVALID_TAG_DESC + CommandTestUtil.VALID_TAG_FRIEND
-                + CommandTestUtil.PRIORITY_DESC_BOB, Tag.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.PRIORITY_DESC_BOB + CommandTestUtil.COMPANY_DESC_BOB,
+                Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.INVALID_NAME_DESC
                 + CommandTestUtil.PHONE_DESC_BOB + CommandTestUtil.EMAIL_DESC_BOB
                 + CommandTestUtil.INVALID_ADDRESS_DESC
-                + CommandTestUtil.PRIORITY_DESC_BOB, PersonName.MESSAGE_CONSTRAINTS);
+                + CommandTestUtil.PRIORITY_DESC_BOB + CommandTestUtil.COMPANY_DESC_BOB,
+                PersonName.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         CommandParserTestUtil.assertParseFailure(parser, CommandTestUtil.PREAMBLE_NON_EMPTY
                 + CommandTestUtil.NAME_DESC_BOB + CommandTestUtil.PHONE_DESC_BOB
                 + CommandTestUtil.EMAIL_DESC_BOB + CommandTestUtil.ADDRESS_DESC_BOB
                 + CommandTestUtil.TAG_DESC_HUSBAND + CommandTestUtil.TAG_DESC_FRIEND
-                + CommandTestUtil.PRIORITY_DESC_BOB,
+                + CommandTestUtil.PRIORITY_DESC_BOB + CommandTestUtil.COMPANY_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddPersonCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
+++ b/src/test/java/connectify/logic/parser/ConnectifyParserTest.java
@@ -59,7 +59,8 @@ public class ConnectifyParserTest {
     @Test
     public void parseCommand_add() throws Exception {
         Person person = new PersonBuilder().build();
-        AddPersonCommand command = (AddPersonCommand) parser.parseCommand(PersonUtil.getAddPersonCommand(person));
+        AddPersonCommand command = (AddPersonCommand) parser.parseCommand(PersonUtil.getAddPersonCommand(person)
+            + PREFIX_COMPANY + INDEX_FIRST_COMPANY.getOneBased());
         assertEquals(new AddPersonCommand(person, INDEX_FIRST_COMPANY), command);
     }
 


### PR DESCRIPTION
Fixes #178 , #151 .

Notable Changes:
- Fix multiple prefixes allowed for notePerson issue
- Fix convulated command result output for notePerson issue
- Fix auto assignment to first company if company index is not specified for addPerson command issue
- Fix incorrect command success result for addPerson command (indicating that company index and priority fields are optional)