### PR TITLE
BugFix priority

### DIFF
--- a/src/main/java/connectify/logic/parser/ParserPersonUtil.java
+++ b/src/main/java/connectify/logic/parser/ParserPersonUtil.java
@@ -142,6 +142,9 @@ public class ParserPersonUtil {
     public static PersonPriority parsePersonPriority(String priority) throws ParseException {
         requireNonNull(priority);
         String trimmedPriority = priority.trim();
+        if (!PersonPriority.isValidPriority(trimmedPriority)) {
+            throw new ParseException(PersonPriority.MESSAGE_CONSTRAINTS);
+        }
         return new PersonPriority(trimmedPriority);
     }
 

--- a/src/main/java/connectify/model/Priority.java
+++ b/src/main/java/connectify/model/Priority.java
@@ -11,7 +11,7 @@ public abstract class Priority {
 
     public static final String VALIDATION_REGEX = "^[0-9]+$";
     public static final String MESSAGE_CONSTRAINTS =
-            "Priority should only contain non-negative numbers, and it should be at least 1 digit long";
+            "Priority should only contain numbers, and it should be at least 1 digit long";
 
     public final Integer value;
 

--- a/src/main/java/connectify/model/Priority.java
+++ b/src/main/java/connectify/model/Priority.java
@@ -11,7 +11,7 @@ public abstract class Priority {
 
     public static final String VALIDATION_REGEX = "^[0-9]+$";
     public static final String MESSAGE_CONSTRAINTS =
-            "Priority should only contain numbers, and it should be at least 1 digit long";
+            "Priority should only contain non-negative numbers, and it should be at least 1 digit long";
 
     public final Integer value;
 


### PR DESCRIPTION
Previously, setting a negative priority would cause `addPerson` and `editPerson` to throw an uncaught exception. This is now fixed and the error message has been updated accordingly.